### PR TITLE
create nullable routes path

### DIFF
--- a/lib/js_rails_routes/route.rb
+++ b/lib/js_rails_routes/route.rb
@@ -16,7 +16,8 @@ module JSRailsRoutes
     def initialize(route)
       @route = route
       @name = route.name
-      @path = route.path.spec.to_s.sub(/\(.:format\)/, '').sub('(', '').sub(')', '')
+      #@path = route.path.spec.to_s.sub(/\(.:format\)/, '').sub('(', '').sub(')', '')
+      @path = route.path.spec.to_s.sub(/\(.:format\)/, '').delete('(').delete(')')
     end
 
     # @return [Boolean]

--- a/lib/js_rails_routes/route.rb
+++ b/lib/js_rails_routes/route.rb
@@ -16,7 +16,7 @@ module JSRailsRoutes
     def initialize(route)
       @route = route
       @name = route.name
-      @path = route.path.spec.to_s.split('(').first
+      @path = route.path.spec.to_s.sub(/\(.:format\)/, "").sub('(', '').sub(')', '')
     end
 
     # @return [Boolean]

--- a/lib/js_rails_routes/route.rb
+++ b/lib/js_rails_routes/route.rb
@@ -16,7 +16,7 @@ module JSRailsRoutes
     def initialize(route)
       @route = route
       @name = route.name
-      @path = route.path.spec.to_s.sub(/\(.:format\)/, "").sub('(', '').sub(')', '')
+      @path = route.path.spec.to_s.sub(/\(.:format\)/, '').sub('(', '').sub(')', '')
     end
 
     # @return [Boolean]

--- a/lib/js_rails_routes/route.rb
+++ b/lib/js_rails_routes/route.rb
@@ -16,7 +16,6 @@ module JSRailsRoutes
     def initialize(route)
       @route = route
       @name = route.name
-      #@path = route.path.spec.to_s.sub(/\(.:format\)/, '').sub('(', '').sub(')', '')
       @path = route.path.spec.to_s.sub(/\(.:format\)/, '').delete('(').delete(')')
     end
 

--- a/spec/js_rails_routes/builder_spec.rb
+++ b/spec/js_rails_routes/builder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe JSRailsRoutes::Builder do
 
   let(:language) { instance_double('JSRailsRoutes::Language::Base', handle_route_set: body, ext: %w[js ts].sample) }
   let(:body) { 'hello' }
-  let(:route_set_list) { [rails_route_set, engine_route_set] }
+  let(:route_set_list) { [rails_route_set, engine_route_set, nullable_scope_route_set] }
 
   let(:rails_route_set) do
     route_set = ActionDispatch::Routing::RouteSet.new.tap do |routes|
@@ -27,15 +27,27 @@ RSpec.describe JSRailsRoutes::Builder do
     JSRailsRoutes::RouteSet.new('Users::Engine', route_set)
   end
 
+  let(:nullable_scope_route_set) do
+    route_set = ActionDispatch::Routing::RouteSet.new.tap do |routes|
+      routes.draw do
+        scope '(:/locale)' do
+          get '/users' => 'users#index'
+        end
+      end
+    end
+    JSRailsRoutes::RouteSet.new('Users::Engine', route_set)
+  end
+
   describe '#build' do
     subject { builder.build }
 
     it 'returns an array of artifacts' do
       expect(subject).to contain_exactly(
         an_object_having_attributes(engine_name: rails_route_set.name, body: body),
-        an_object_having_attributes(engine_name: engine_route_set.name, body: body)
+        an_object_having_attributes(engine_name: engine_route_set.name, body: body),
+        an_object_having_attributes(engine_name: nullable_scope_route_set.name, body: body)
       )
-      expect(language).to have_received(:handle_route_set).twice
+      expect(language).to have_received(:handle_route_set).exactly(3).times
     end
   end
 end

--- a/spec/js_rails_routes/language/javascript_spec.rb
+++ b/spec/js_rails_routes/language/javascript_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe JSRailsRoutes::Language::JavaScript do
       rails_route_set = ActionDispatch::Routing::RouteSet.new.tap do |routes|
         routes.draw do
           resources :articles
+          scope '(/:locale)' do
+            get '/users' => 'users#index'
+          end
         end
       end
       JSRailsRoutes::RouteSet.new('Rails', rails_route_set)
@@ -43,6 +46,7 @@ RSpec.describe JSRailsRoutes::Language::JavaScript do
           export function new_article_path(params) { return process('/articles/new', params, []); }
           export function edit_article_path(params) { return process('/articles/' + params.id + '/edit', params, ['id']); }
           export function article_path(params) { return process('/articles/' + params.id + '', params, ['id']); }
+          export function users_path(params) { return process('/' + params.locale + '/users', params, ['locale']); }
         JAVASCRIPT
       end
     end
@@ -61,6 +65,7 @@ RSpec.describe JSRailsRoutes::Language::JavaScript do
           export function newArticlePath(params) { return process('/articles/new', params, []); }
           export function editArticlePath(params) { return process('/articles/' + params.id + '/edit', params, ['id']); }
           export function articlePath(params) { return process('/articles/' + params.id + '', params, ['id']); }
+          export function usersPath(params) { return process('/' + params.locale + '/users', params, ['locale']); }
         JAVASCRIPT
       end
     end
@@ -79,6 +84,7 @@ RSpec.describe JSRailsRoutes::Language::JavaScript do
           export function NewArticlePath(params) { return process('/articles/new', params, []); }
           export function EditArticlePath(params) { return process('/articles/' + params.Id + '/edit', params, ['Id']); }
           export function ArticlePath(params) { return process('/articles/' + params.Id + '', params, ['Id']); }
+          export function UsersPath(params) { return process('/' + params.Locale + '/users', params, ['Locale']); }
         JAVASCRIPT
       end
     end
@@ -111,6 +117,7 @@ RSpec.describe JSRailsRoutes::Language::JavaScript do
           export function articles_path(params) { return process('/articles', params, []); }
           export function edit_article_path(params) { return process('/articles/' + params.id + '/edit', params, ['id']); }
           export function article_path(params) { return process('/articles/' + params.id + '', params, ['id']); }
+          export function users_path(params) { return process('/' + params.locale + '/users', params, ['locale']); }
         JAVASCRIPT
       end
     end
@@ -143,6 +150,7 @@ RSpec.describe JSRailsRoutes::Language::JavaScript do
           export function articles_path(params) { return process('/articles', params, []); }
           export function edit_article_path(params) { return process('/articles/' + params.id + '/edit', params, ['id']); }
           export function article_path(params) { return process('/articles/' + params.id + '', params, ['id']); }
+          export function users_path(params) { return process('/' + params.locale + '/users', params, ['locale']); }
         JAVASCRIPT
       end
     end

--- a/spec/js_rails_routes/route_set_spec.rb
+++ b/spec/js_rails_routes/route_set_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe JSRailsRoutes::RouteSet do
       routes.draw do
         get '/articles' => 'articles#index'
         get '/users' => 'users#index'
+        scope '(/:locale)' do
+          get '/users' => 'users#index'
+        end
       end
     end
   end
@@ -48,6 +51,7 @@ RSpec.describe JSRailsRoutes::RouteSet do
       it "doesn't include the excluded route" do
         expect(subject).to include be_a(JSRailsRoutes::Route).and(have_attributes(name: /articles/))
         expect(subject).not_to include be_a(JSRailsRoutes::Route).and(have_attributes(name: /users/))
+        expect(subject).not_to include be_a(JSRailsRoutes::Route).and(have_attributes(name: /:locale/))
       end
     end
   end

--- a/spec/js_rails_routes/route_spec.rb
+++ b/spec/js_rails_routes/route_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe JSRailsRoutes::Route do
   subject(:route) { described_class.new(raw_route) }
+  subject(:nullable_scope_route) { described_class.new(nullable_scope_raw_route) }
 
   include_context 'run in a sandbox'
 
@@ -9,6 +10,16 @@ RSpec.describe JSRailsRoutes::Route do
     ActionDispatch::Routing::RouteSet.new.tap do |routes|
       routes.draw do
         get '/articles' => 'articles#index'
+      end
+    end.routes.first
+  end
+
+  let(:nullable_scope_raw_route) do
+    ActionDispatch::Routing::RouteSet.new.tap do |routes|
+      routes.draw do
+        scope '(/:locale)' do
+          get '/users' => 'users#index'
+        end
       end
     end.routes.first
   end
@@ -31,6 +42,10 @@ RSpec.describe JSRailsRoutes::Route do
     subject { route.path }
 
     it { is_expected.to eq '/articles' }
+
+    it 'returns url include nullable scope' do
+      expect(nullable_scope_route.path).to eq '/:locale/users'
+    end
   end
 
   describe '#match?' do


### PR DESCRIPTION
- before

`@path = route.path.spec.to_s.split('(').first`

route.path.spec.to_sが `(/:locale)/:account/failed_create_item(.:format)` こうなってるので
splitすると `["", "/:locale)/:account/failed_create_item", ".:format)"]` こうなる。
これのfirstをとると `@path = ""` となり、
nullableなscope (/:locale) が含まれると空文字が返っていた。

- after

`@path = route.path.spec.to_s.sub(/\(.:format\)/, "").sub('(', '').sub(')', '')`

`(.:format)` これを削除したあとに `(` と `)` を削除してそれらしいパスになるようにした。